### PR TITLE
Run CI for Python v3.10, v3.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ workflows:
       - python-3.9
       - python-3.10
       - python-3.11
-      - python-3.12
       - deploy:
           context: pypi
           requires:
@@ -30,7 +29,11 @@ jobs:
       - checkout
 
       - restore_cache:
-          key: deps-{{ .Branch }}-{{ checksum "setup.py" }}
+          keys:
+            - deps-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+            - deps-{{ .Branch }}-{{ checksum "setup.py" }}-
+            - deps-{{ .Branch }}-
+            - deps-
 
       - run:
           name: install requirements
@@ -39,18 +42,13 @@ jobs:
             . venv/bin/activate
             pip install tox
             pip install -e .[examples]
+            tox --notest  # Install all tox dependencies
+
       - save_cache:
-          paths: venv
-          key: deps-{{ .Branch }}-{{ checksum "setup.py" }}
-
-      - restore_cache:
-          key: tox-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
-
-      - run:
-          name: run tests
-          command: |
-            . venv/bin/activate
-            tox -e $TOX_ENV
+          paths:
+            - venv
+            - .tox
+          key: deps-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
       - run:
           name: run linters
@@ -58,9 +56,11 @@ jobs:
             . venv/bin/activate
             tox -e mypy,flake8
 
-      - save_cache:
-          paths: .tox
-          key: tox-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+      - run:
+          name: run tests
+          command: |
+            . venv/bin/activate
+            tox -e $TOX_ENV
 
   python-3.8:
     <<: *build-template
@@ -89,13 +89,6 @@ jobs:
       - image: cimg/python:3.11
         environment:
           TOX_ENV: py311
-
-  python-3.12:
-    <<: *build-template
-    docker:
-      - image: cimg/python:3.12
-        environment:
-          TOX_ENV: py312
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,10 +30,10 @@ jobs:
 
       - restore_cache:
           keys:
-            - deps-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
-            - deps-{{ .Branch }}-{{ checksum "setup.py" }}-
-            - deps-{{ .Branch }}-
-            - deps-
+            - deps-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+            - deps-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "setup.py" }}-
+            - deps-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-
+            - deps-{{ .Environment.CACHE_VERSION }}-
 
       - run:
           name: install requirements
@@ -48,13 +48,13 @@ jobs:
           paths:
             - venv
             - .tox
-          key: deps-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+          key: deps-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
       - run:
           name: run linters
           command: |
             . venv/bin/activate
-            tox -e mypy,flake8
+            tox -e mypy,linter
 
       - run:
           name: run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ workflows:
       - python-3.7
       - python-3.8
       - python-3.9
+      - python-3.10
+      - python-3.11
+      - python-3.12
       - deploy:
           context: pypi
           requires:
@@ -19,7 +22,7 @@ jobs:
   python-3.7: &build-template
     working_directory: ~/app
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOX_ENV: py37
 
@@ -62,20 +65,41 @@ jobs:
   python-3.8:
     <<: *build-template
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
         environment:
           TOX_ENV: py38
 
   python-3.9:
     <<: *build-template
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
         environment:
           TOX_ENV: py39
 
+  python-3.10:
+    <<: *build-template
+    docker:
+      - image: cimg/python:3.10
+        environment:
+          TOX_ENV: py310
+
+  python-3.11:
+    <<: *build-template
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          TOX_ENV: py311
+
+  python-3.12:
+    <<: *build-template
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          TOX_ENV: py312
+
   deploy:
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
 
     working_directory: ~/uhlive
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,10 +30,10 @@ jobs:
 
       - restore_cache:
           keys:
-            - deps-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
-            - deps-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "setup.py" }}-
-            - deps-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-
-            - deps-{{ .Environment.CACHE_VERSION }}-
+            - deps-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+            - deps-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "setup.py" }}-
+            - deps-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-
+            - deps-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CACHE_VERSION }}-
 
       - run:
           name: install requirements
@@ -48,7 +48,7 @@ jobs:
           paths:
             - venv
             - .tox
-          key: deps-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+          key: deps-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
       - run:
           name: run linters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ workflows:
 
 jobs:
   python-3.7: &build-template
+    resource_class: small
     working_directory: ~/app
     docker:
       - image: cimg/python:3.7
@@ -91,6 +92,7 @@ jobs:
           TOX_ENV: py311
 
   deploy:
+    resource_class: small
     docker:
       - image: cimg/python:3.7
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ envlist =
     py39
     py310
     py311
+    py312
     isort
     black
     flake8

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ envlist =
     py39
     py310
     py311
-    py312
     isort
     black
     flake8

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ envlist =
     py311
     isort
     black
-    flake8
+    linter
     mypy
 skip_missing_interpreters = true
 
@@ -20,19 +20,12 @@ skip_missing_interpreters = true
 commands =
     python setup.py test
 
-[isort]
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses=True
-line_length=88
-
 [testenv:isort]
 skip_install = true
 deps =
     isort
 commands =
-    python -m isort -rc src examples tests setup.py
+    isort --profile black src examples tests setup.py
 
 [testenv:black]
 skip_install = true
@@ -41,17 +34,12 @@ deps =
 commands =
     black src examples tests setup.py
 
-[flake8]
-max-line-length = 80
-select = C,E,F,W,B,B950
-ignore = E203, E501, W503
-
-[testenv:flake8]
+[testenv:linter]
 skip_install = true
 deps =
-    flake8
+    ruff
 commands =
-    flake8 src examples tests setup.py
+    ruff check src examples tests setup.py
 
 [testenv:mypy]
 extras = examples


### PR DESCRIPTION
- run CI for Python v3.10 and v3.11 (currently failing with v3.12 because of setuptools)
- use ruff
- improve CI caching and performance